### PR TITLE
Install New SDL2 if not already installed

### DIFF
--- a/core.sh
+++ b/core.sh
@@ -62,6 +62,11 @@ echo
 read -p "Make a selection: " userInput
 
 echo "you have chosen $userInput"
+
+if [[ $userInput != X]]; then
+  bash -c "$(curl -s https://raw.githubusercontent.com/cobalt2727/L4T-Megascript/master/scripts/sdl2_install_helper.sh)"
+fi
+
 if [[ $userInput == 0 || $userInput == setup ]]; then
   bash -c "$(curl -s https://raw.githubusercontent.com/cobalt2727/L4T-Megascript/master/scripts/init.sh)"
   

--- a/core_gui.sh
+++ b/core_gui.sh
@@ -29,8 +29,13 @@ CHOICE=$(zenity \
     FALSE "CSE2" "An enhanced version of Cave Story. 60 FPS and other soundtracks support"\
     FALSE "Citra" "3DS emulator, currently broken")
     
-PRIVATE=`zenity --password`
 
+
+if ["$?" != 0 ]
+then
+PRIVATE=`zenity --password`
+echo $PRIVATE | sudo -S curl -L https://raw.githubusercontent.com/cobalt2727/L4T-Megascript/master/scripts/sdl2_install_helper.sh | bash
+fi
 if echo $CHOICE | grep -q "RetroPie";
 then echo "install retropie..."
 #zenity --progress --text="Installing retropie" --percentage=0 | 

--- a/scripts/sdl2_install_helper.sh
+++ b/scripts/sdl2_install_helper.sh
@@ -1,0 +1,20 @@
+cd
+if dpkg -s libsdl2-dev | grep "2.0.10+5"; then
+echo ""
+echo "Already Installed Newest SDL2 Version"
+sleep 1
+else
+sudo apt-get --assume-yes install git
+sudo rm -rf temp_install
+mkdir temp_install
+cd temp_install
+git clone --depth=1 https://github.com/theofficialgman/RetroPie-Setup.git
+#auto install sdl2 and then remove unneeded files
+cd RetroPie-Setup
+sudo ./retropie_packages.sh sdl2
+cd
+sudo rm -rf temp_install
+echo ""
+echo "Successfully Installed Newest SDL2 Version"
+sleep 3
+fi


### PR DESCRIPTION
Checks sdl2 version installed and only installs if new version is not already installed. Happens in both core_gui.sh and core.sh if user chooses any option besides exit. This should Fix DBUS errors permanently