### PR TITLE
update sdl2 script to not require entire retropie_setup script repository

### DIFF
--- a/scripts/sdl2_install_helper.sh
+++ b/scripts/sdl2_install_helper.sh
@@ -1,19 +1,33 @@
 cd
-if dpkg -s libsdl2-dev | grep "2.0.10+5"; then
+if dpkg -s libsdl2-dev | grep -q "2.0.10+5"; then
 echo ""
 echo "Already Installed Newest SDL2 Version"
 sleep 1
 else
 sudo apt-get --assume-yes install git
-sudo rm -rf temp_install
-mkdir temp_install
-cd temp_install
-git clone --depth=1 https://github.com/theofficialgman/RetroPie-Setup.git
+cd /tmp
+mkdir temp_install_sdl2
+cd temp_install_sdl2
+curl -s 'https://raw.githubusercontent.com/theofficialgman/RetroPie-Setup/master/retropie_packages.sh' > retropie_packages.sh
+chmod -R 777 retropie_packages.sh
+curl -s 'https://raw.githubusercontent.com/theofficialgman/RetroPie-Setup/master/retropie_setup.sh' > retropie_setup.sh
+mkdir scriptmodules
+cd ./scriptmodules
+curl -s 'https://raw.githubusercontent.com/theofficialgman/RetroPie-Setup/master/scriptmodules/system.sh' > system.sh
+curl -s 'https://raw.githubusercontent.com/theofficialgman/RetroPie-Setup/master/scriptmodules/helpers.sh' > helpers.sh
+curl -s 'https://raw.githubusercontent.com/theofficialgman/RetroPie-Setup/master/scriptmodules/packages.sh' > packages.sh
+curl -s 'https://raw.githubusercontent.com/theofficialgman/RetroPie-Setup/master/scriptmodules/inifuncs.sh' > inifuncs.sh
+mkdir supplementary
+cd ./supplementary
+curl -s 'https://raw.githubusercontent.com/theofficialgman/RetroPie-Setup/master/scriptmodules/supplementary/sdl2.sh' > sdl2.sh
+cd /tmp/temp_install_sdl2
+
+
 #auto install sdl2 and then remove unneeded files
-cd RetroPie-Setup
 sudo ./retropie_packages.sh sdl2
+cd /tmp
+sudo rm -rf temp_install_sdl2
 cd
-sudo rm -rf temp_install
 echo ""
 echo "Successfully Installed Newest SDL2 Version"
 sleep 3


### PR DESCRIPTION
kinda a hack still as I still use the setup script but now we only download the required files but not to /tmp directory where I actually delete them afterwards. Honestly you can think of this as a dependency.

PS: I'd still like this to run whenever installing a game. It does nothing if the correct version of sdl2 is installed. At minimum we need to break up the init.sh script because I imagine most people won't want to do everything contained in it. 