### PR TITLE
scripts: FEX.sh: Various fixes

### DIFF
--- a/scripts/FEX.sh
+++ b/scripts/FEX.sh
@@ -14,21 +14,21 @@ fi
 if package_installed "clang++-13" ;then
   sudo apt remove clang++-13 -y
 fi
-if package_installed "libclang13-dev" ;then
-  sudo apt remove libclang13-dev -y
+if package_installed "libclang-13-dev" ;then
+  sudo apt remove libclang-13-dev -y
 fi
 if package_installed "libmlir-13-dev" ;then
   sudo apt remove libmlir-13-dev -y
 fi
 
-if grep -q bionic /etc/os-release; then
+if grep -q bionic /etc/os-release || grep -q focal /etc/os-release; then
   #installs latest stable LLVM toolchain (may need this on Focal now or in the future, untested)
   curl https://apt.llvm.org/llvm.sh | sudo bash -s "14" || error "apt.llvm.org installer failed!"
 
   ppa_name="ubuntu-toolchain-r/test" && ppa_installer
-  sudo apt install -y libstdc++-11-dev libstdc++6 gcc-11 g++-11 clang-14 clang++-14 || error "Failed to install dependencies!"
+  sudo apt install -y libstdc++-11-dev libstdc++6 libstdc++6-dev libclang-14-dev gcc-11 g++-11 clang-14 clang++-14 || error "Failed to install dependencies!"
 else #this might be insufficient on Focal, needs testing
-  sudo apt install -y libstdc++-11-dev libstdc++6 gcc g++ clang clang++ || error "Failed to install dependencies!"
+  sudo apt install -y libstdc++-11-dev libstdc++6 libstdc++6-dev libclang-dev gcc g++ clang clang++ || error "Failed to install dependencies!"
 fi
 
 git clone https://github.com/FEX-Emu/FEX.git --recurse-submodules -j$(nproc)
@@ -47,8 +47,8 @@ fi
 
 #NOTE: make sure to set -DBUILD_TESTS=True when testing to ensure maximum compatibility (broken as of Jan 10, 2022) https://github.com/FEX-Emu/FEX/issues/1423
 if grep -q bionic /etc/os-release; then
-  CC=clang-14 CXX=clang++-14 cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DENABLE_LTO=True -DCMAKE_C_FLAGS_INIT="-static" -DBUILD_TESTS=False -G Ninja .. || error "cmake failed!"
-  CC=clang-14 CXX=clang++-14 ninja || error "Failed to build!"
+  CC=clang-14 CXX=clang++-14 AR=llvm-ar-14 LINKER=lld-14 NM=llvm-nm-14 OBJDUMP=llvm-objdump-14 RANLIB=llvm-ranlib-14 cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DENABLE_LTO=True -DCMAKE_C_FLAGS_INIT="-static" -DBUILD_TESTS=False -G Ninja .. || error "cmake failed!"
+  CC=clang-14 CXX=clang++-14 AR=llvm-ar-14 LINKER=lld-14 NM=llvm-nm-14 OBJDUMP=llvm-objdump-14 RANLIB=llvm-ranlib-14 ninja || error "Failed to build!"
 else
   CC=clang CXX=clang++ cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DENABLE_LTO=True -DBUILD_TESTS=False -G Ninja .. || error "cmake failed!"
   CC=clang CXX=clang++ ninja || error "Failed to build!"

--- a/scripts/FEX.sh
+++ b/scripts/FEX.sh
@@ -25,7 +25,7 @@ if grep -q bionic /etc/os-release || grep -q focal /etc/os-release; then
   ppa_name="ubuntu-toolchain-r/test" && ppa_installer
   sudo apt install -y libstdc++-11-dev libstdc++6 libclang-14-dev gcc-11 g++-11 clang-14 || error "Failed to install dependencies!"
 else #this might be insufficient on Focal, needs testing
-  sudo apt install -y libstdc++-11-dev libstdc++6 libstdc++6-dev libclang-dev gcc g++ clang || error "Failed to install dependencies!"
+  sudo apt install -y libstdc++-11-dev libstdc++6 libclang-dev gcc g++ clang || error "Failed to install dependencies!"
 fi
 
 git clone https://github.com/FEX-Emu/FEX.git --recurse-submodules -j$(nproc)

--- a/scripts/FEX.sh
+++ b/scripts/FEX.sh
@@ -11,9 +11,6 @@ fi
 if package_installed "clang-13" ;then
   sudo apt remove clang-13 -y
 fi
-if package_installed "clang++-13" ;then
-  sudo apt remove clang++-13 -y
-fi
 if package_installed "libclang-13-dev" ;then
   sudo apt remove libclang-13-dev -y
 fi
@@ -26,9 +23,9 @@ if grep -q bionic /etc/os-release || grep -q focal /etc/os-release; then
   curl https://apt.llvm.org/llvm.sh | sudo bash -s "14" || error "apt.llvm.org installer failed!"
 
   ppa_name="ubuntu-toolchain-r/test" && ppa_installer
-  sudo apt install -y libstdc++-11-dev libstdc++6 libstdc++6-dev libclang-14-dev gcc-11 g++-11 clang-14 clang++-14 || error "Failed to install dependencies!"
+  sudo apt install -y libstdc++-11-dev libstdc++6 libclang-14-dev gcc-11 g++-11 clang-14 || error "Failed to install dependencies!"
 else #this might be insufficient on Focal, needs testing
-  sudo apt install -y libstdc++-11-dev libstdc++6 libstdc++6-dev libclang-dev gcc g++ clang clang++ || error "Failed to install dependencies!"
+  sudo apt install -y libstdc++-11-dev libstdc++6 libstdc++6-dev libclang-dev gcc g++ clang || error "Failed to install dependencies!"
 fi
 
 git clone https://github.com/FEX-Emu/FEX.git --recurse-submodules -j$(nproc)
@@ -42,7 +39,7 @@ cd Build
 
 #nuke unneeded versions
 if package_installed "llvm-13" ;then
-  sudo apt remove llvm-13 clang-13 clang++-13 -y
+  sudo apt remove llvm-13 clang-13 -y
 fi
 
 #NOTE: make sure to set -DBUILD_TESTS=True when testing to ensure maximum compatibility (broken as of Jan 10, 2022) https://github.com/FEX-Emu/FEX/issues/1423


### PR DESCRIPTION
Fix typo in libclang-XX-dev dependency. Force the use of llvm-14 (otherwise it defaults to lowest installed llvm). Add support for focal (tested and works).