### PR TITLE
Add support for OpenMW

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,5 @@ You're in luck - we've got a Discord server: [![Discord invite](https://discord.
 - SuperTux: Developers, SuperTux2
 - n64decomp: Responsible for the SM64 Decompilation Project
 - sm64pc: Adapted the SM64 Port to work with ARM64 devices
+- OpenMW: Developers, OpenMW
 - many more!

--- a/megascript_apps.txt
+++ b/megascript_apps.txt
@@ -24,6 +24,8 @@ fn="Minecraft Bedrock";;d="Android Minecraft Bedrock Version. Ownership of the A
 
 fn="Metaforce";;d="(WARNING - this script is experimental) An attempt to recreate the engine for Retro Studios' GameCube/Wii games, currently only supports Metroid Prime 1 with keyboard controls or a Wii U Gamecube Adapter";;sn="metaforce.sh";;f="games_and_emulators"
 
+fn="OpenMW";;d="An open source re-implementation and extension of the Gamebryo engine for Morrowind.";;sn="openmw.sh";;f="games_and_emulators"
+
 fn="SM64Port";;d="A native port of the classic game for the N64 (requires a ROM)";;sn="SM64.sh";;f="games_and_emulators"
 
 fn="Citra";;d="3DS emulator";;sn="citra.sh";;f="games_and_emulators"

--- a/scripts/games_and_emulators/openmw.sh
+++ b/scripts/games_and_emulators/openmw.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+clear -x
+echo "OpenMW script successfully started!"
+echo "Credits: https://wiki.openmw.org/index.php/Development_Environment_Setup#Linux"
+sleep 3
+
+get_system || error "Failed to scan your sytem specs"
+
+echo "Running updates..."
+sleep 1
+
+if grep -q bionic /etc/os-release; then
+  echo "          -------UBUNTU 18.04 DETECTED-------"
+  echo
+  echo "theofficialgman has done his PPA Qt5 wizardry"
+  echo "enjoy OpenMW on Ubuntu Bionic, Focal, Hirsute, and beyond"
+
+  get_system
+  ppa_name="theofficialgman/opt-qt-5.15.2-bionic-arm"
+  ppa_installer
+  sudo apt install qt5153d qt515base qt515declarative qt515gamepad \
+    qt515graphicaleffects qt515imageformats qt515multimedia \
+    qt515xmlpatterns -y || error "Could not install dependencies"
+
+  echo "Installing GCC/G++ 11..."
+  ppa_name="ubuntu-toolchain-r/test" && ppa_installer
+  sudo apt install gcc-11 g++-11 -y
+
+  echo "Installing dependencies..."
+  sleep 1
+  sudo apt-get install git build-essential cmake libopenal-dev libbullet-dev libsdl2-dev \
+    libmygui-dev libunshield-dev liblz4-dev libtinyxml-dev libqt5opengl5-dev \
+    libboost-filesystem-dev libboost-program-options-dev libboost-iostreams-dev \
+    libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev \
+    librecast-dev libluajit-5.1-dev libsqlite3-dev libyaml-cpp-dev -y \
+    || error "Could not install dependencies"
+
+  echo "Building OpenSceneGraph..."
+  sleep 1
+  cd ~
+  git clone -j$(($(nproc)-1)) https://github.com/OpenMW/osg -b 3.6
+  cd osg
+  git pull -j$(($(nproc)-1)) || error "Could not pull latest source code"
+  mkdir -p build
+  cd build
+  rm -rf CMakeCache.txt
+
+  cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-mcpu=native -DCMAKE_C_FLAGS=-mcpu=native \
+    -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11
+  make -j$(($(nproc)-1)) || error "Compilation failed"
+  sudo make install || error "Make install failed"
+  echo "Successfully installed OpenSceneGraph!"
+
+  echo "Building OpenMW..."
+  sleep 1
+  cd ~
+  git clone -j$(($(nproc)-1)) https://gitlab.com/OpenMW/openmw -b openmw-47
+  cd openmw
+  git pull -j$(($(nproc)-1)) || error "Could not pull latest source code"
+  mkdir -p build
+  cd build
+  rm -rf CMakeCache.txt
+
+  cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-mcpu=native -DCMAKE_C_FLAGS=-mcpu=native \
+    -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11
+  make -j$(($(nproc)-1)) || error "Compilation failed"
+  sudo make install || error "Make install failed"
+
+  echo "Removing build files..."
+  sleep 1
+  cd ~
+  rm -rf openmw osg
+else
+  echo "Adding OpenMW PPA"
+  ppa_name="openmw/openmw" && ppa_installer
+
+  echo "Installing OpenMW..."
+  sudo apt install openmw openmw-launcher -y || error "Failed to install OpenMW"
+fi
+
+echo "Successfully installed OpenMW!"
+echo "Sending you back to the main menu..."
+sleep 5


### PR DESCRIPTION
Currently, the PPA for OpenMW is broken on Bionic for aarch64 so we need to build OpenMW and OpenMW's implementation of OpenSceneGraph from source on 18.04.

On later versions of Ubuntu, simply add the PPA and proceed with installation as usual.