### PR TITLE
Retropie added Supermodel3

### DIFF
--- a/scripts/games_and_emulators/retropie_auto.sh
+++ b/scripts/games_and_emulators/retropie_auto.sh
@@ -42,6 +42,7 @@ _EOF_"
   sudo ./retropie_packages.sh mupen64plus
   # sudo ./retropie_packages.sh lr-duckstation
   sudo ./retropie_packages.sh lzdoom
+  sudo ./retropie_packages.sh supermodel3
   # sudo ./retropie_packages.sh scraper
   # sudo ./retropie_packages.sh skyscraper
   # sudo ./retropie_packages.sh usbromservice


### PR DESCRIPTION
Now there are Supermodel3 from emulationstation in retropie script.  
You just have to copy into the arcade folder platform . 
Do not uninstall runcommand otherwise the option with RES defined resolution will not work.